### PR TITLE
Fix how the google maps JS API is loaded in the browser

### DIFF
--- a/src/Helper/ApiHelper.php
+++ b/src/Helper/ApiHelper.php
@@ -87,14 +87,8 @@ class ApiHelper extends AbstractHelper
             $this->jsonBuilder->setValue('[callback]', $callback, false);
         }
 
-        $callbackFunction = 'load_ivory_google_map_api';
-        $url = sprintf('//www.google.com/jsapi?callback=%s', $callbackFunction);
-        $loader = sprintf('google.load("maps", "3", %s);', $this->jsonBuilder->build());
-
+        $url = sprintf('https://maps.googleapis.com/maps/api/js?key=%s', $api_key);
         $output = array();
-        $output[] = '<script type="text/javascript">'.PHP_EOL;
-        $output[] = sprintf('function %s () { %s };'.PHP_EOL, $callbackFunction, $loader);
-        $output[] = '</script>'.PHP_EOL;
         $output[] = sprintf('<script type="text/javascript" src="%s"></script>'.PHP_EOL, $url);
 
         $this->loaded = true;


### PR DESCRIPTION
Google changed how their AJAX loader is used (... I think).

This updates the library to load google maps from the `https://maps.googleapis.com/maps/api/js` URL instead.

Everything seems to work as expected (for the use case of SimplyRETS/simplyretswp), but still needs some testing.